### PR TITLE
Implement UI for online count

### DIFF
--- a/themes/nodebb-theme-persona/templates/partials/groups/groupOnlineCount.tpl
+++ b/themes/nodebb-theme-persona/templates/partials/groups/groupOnlineCount.tpl
@@ -1,0 +1,3 @@
+<div>
+    <h4> Currently online: {groups.onlineUserCount} 10 </h4>
+</div>

--- a/themes/nodebb-theme-persona/templates/partials/groups/groupOnlineCount.tpl
+++ b/themes/nodebb-theme-persona/templates/partials/groups/groupOnlineCount.tpl
@@ -1,3 +1,3 @@
 <div>
-    <h4> Currently online: {groups.onlineUserCount} 10 </h4>
+    <h4> Currently online: {groups.onlineUserCount}</h4>
 </div>

--- a/themes/nodebb-theme-persona/templates/partials/groups/list.tpl
+++ b/themes/nodebb-theme-persona/templates/partials/groups/list.tpl
@@ -15,8 +15,7 @@
                     <li class="truncated"><i class="fa fa-ellipsis-h"></i></li>
                     <!-- ENDIF groups.truncated -->
                 </ul>
-                <h4>Currently online: 10 </h4>
-                <!-- insert here -->
+                <!-- IMPORT partials/groups/groupOnlineCount.tpl -->
             </div>
         </div>
     </div>

--- a/themes/nodebb-theme-persona/templates/partials/groups/list.tpl
+++ b/themes/nodebb-theme-persona/templates/partials/groups/list.tpl
@@ -15,6 +15,8 @@
                     <li class="truncated"><i class="fa fa-ellipsis-h"></i></li>
                     <!-- ENDIF groups.truncated -->
                 </ul>
+                <h4>Currently online: 10 </h4>
+                <!-- insert here -->
             </div>
         </div>
     </div>

--- a/themes/nodebb-theme-persona/templates/partials/groups/memberlist.tpl
+++ b/themes/nodebb-theme-persona/templates/partials/groups/memberlist.tpl
@@ -16,7 +16,7 @@
     <tbody>
     {{{each group.members}}}
     <tr data-uid="{group.members.uid}">
-        <h4>Currently online: 10 </h4>
+        <!-- IMPORT partials/groups/groupOnlineCount.tpl -->
         <td>
             <a href="{config.relative_path}/user/{group.members.userslug}">{buildAvatar(group.members, "sm", true)}</a>
         </td>

--- a/themes/nodebb-theme-persona/templates/partials/groups/memberlist.tpl
+++ b/themes/nodebb-theme-persona/templates/partials/groups/memberlist.tpl
@@ -16,6 +16,7 @@
     <tbody>
     {{{each group.members}}}
     <tr data-uid="{group.members.uid}">
+        <h4>Currently online: 10 </h4>
         <td>
             <a href="{config.relative_path}/user/{group.members.userslug}">{buildAvatar(group.members, "sm", true)}</a>
         </td>

--- a/themes/nodebb-theme-persona/templates/partials/groups/onlineCount.tpl
+++ b/themes/nodebb-theme-persona/templates/partials/groups/onlineCount.tpl
@@ -1,0 +1,4 @@
+<div>
+ Online Users
+ {groups.onlineUserCount}
+</div>

--- a/themes/nodebb-theme-persona/templates/partials/groups/onlineCount.tpl
+++ b/themes/nodebb-theme-persona/templates/partials/groups/onlineCount.tpl
@@ -1,4 +1,0 @@
-<div>
- Online Users
- {groups.onlineUserCount}
-</div>

--- a/themes/nodebb-theme-persona/templates/partials/groups/userOnlineCount.tpl
+++ b/themes/nodebb-theme-persona/templates/partials/groups/userOnlineCount.tpl
@@ -1,1 +1,1 @@
-<h6> ({groups.onlineUserCount}10) </h6>
+<h6> ({groups.onlineUserCount}) </h6>

--- a/themes/nodebb-theme-persona/templates/partials/groups/userOnlineCount.tpl
+++ b/themes/nodebb-theme-persona/templates/partials/groups/userOnlineCount.tpl
@@ -1,0 +1,1 @@
+<h6> ({groups.onlineUserCount}10) </h6>

--- a/themes/nodebb-theme-persona/templates/partials/users_list_menu.tpl
+++ b/themes/nodebb-theme-persona/templates/partials/users_list_menu.tpl
@@ -1,5 +1,5 @@
 <ul class="nav nav-pills">
-    <li><a href="{config.relative_path}/users?section=online">[[global:online]]</a></li>
+    <li><a href="{config.relative_path}/users?section=online">[[global:online]] (32)</a></li>
     <li><a href="{config.relative_path}/users?section=sort-posts">[[users:top_posters]]</a></li>
     <!-- IF !reputation:disabled -->
     <li><a href="{config.relative_path}/users?section=sort-reputation">[[users:most_reputation]]</a></li>

--- a/themes/nodebb-theme-persona/templates/partials/users_list_menu.tpl
+++ b/themes/nodebb-theme-persona/templates/partials/users_list_menu.tpl
@@ -1,5 +1,7 @@
 <ul class="nav nav-pills">
-    <li><a href="{config.relative_path}/users?section=online">[[global:online]] (32)</a></li>
+    <li>
+        <a href="{config.relative_path}/users?section=online">[[global:online]] <!-- IMPORT partials/groups/userOnlineCount.tpl --> </a>
+    </li>
     <li><a href="{config.relative_path}/users?section=sort-posts">[[users:top_posters]]</a></li>
     <!-- IF !reputation:disabled -->
     <li><a href="{config.relative_path}/users?section=sort-reputation">[[users:most_reputation]]</a></li>


### PR DESCRIPTION
Addresses Issue #9 

- Added UI design and placeholders for online user count for the User and Group page
- Changes made in following files:
  - `themes/nodebb-theme-persona/templates/partials/users_list_menu.tpl` (User page)
  - `themes/nodebb-theme-persona/templates/partials/groups/userOnlineCount.tpl` (Group page)
  - `themes/nodebb-theme-persona/templates/partials/groups/memberlist.tpl` (Within Group page, member list area)
- Files added:
  - `themes/nodebb-theme-persona/templates/partials/groups/userOnlineCount.tpl` (Count for User page)
  - `themes/nodebb-theme-persona/templates/partials/groups/groupOnlineCount.tpl` (Count for Group and within Group page)
- See attached photos for details

<img width="1368" alt="Screenshot 2023-09-22 at 2 48 57 PM" src="https://github.com/CMU-313/fall23-nodebb-formula1/assets/94590737/38ecbbee-f3d3-49be-836d-1dd1776370ea">
<img width="1368" alt="Screenshot 2023-09-22 at 2 49 02 PM" src="https://github.com/CMU-313/fall23-nodebb-formula1/assets/94590737/b32087d4-aa8d-4afc-971f-0627b3065f79">
<img width="1368" alt="Screenshot 2023-09-22 at 2 49 06 PM" src="https://github.com/CMU-313/fall23-nodebb-formula1/assets/94590737/626d9a5a-6031-428d-828e-b645ac0cf8c6">
