### PR TITLE
Fixed Errors with User Count UI Display

### DIFF
--- a/themes/nodebb-theme-persona/templates/partials/groups/groupOnlineCount.tpl
+++ b/themes/nodebb-theme-persona/templates/partials/groups/groupOnlineCount.tpl
@@ -1,3 +1,3 @@
 <div>
-    <h4> Currently online: {groups.onlineUserCount}</h4>
+    <h4> Currently online: {group.onlineUserCount}</h4>
 </div>

--- a/themes/nodebb-theme-persona/templates/partials/groups/groupsOnlineCount.tpl
+++ b/themes/nodebb-theme-persona/templates/partials/groups/groupsOnlineCount.tpl
@@ -1,0 +1,3 @@
+<div>
+    <h4> Currently online: {groups.onlineUserCount}</h4>
+</div>

--- a/themes/nodebb-theme-persona/templates/partials/groups/list.tpl
+++ b/themes/nodebb-theme-persona/templates/partials/groups/list.tpl
@@ -15,7 +15,7 @@
                     <li class="truncated"><i class="fa fa-ellipsis-h"></i></li>
                     <!-- ENDIF groups.truncated -->
                 </ul>
-                <!-- IMPORT partials/groups/groupOnlineCount.tpl -->
+                <!-- IMPORT partials/groups/groupsOnlineCount.tpl -->
             </div>
         </div>
     </div>

--- a/themes/nodebb-theme-persona/templates/partials/groups/memberlist.tpl
+++ b/themes/nodebb-theme-persona/templates/partials/groups/memberlist.tpl
@@ -14,9 +14,9 @@
 
 <table component="groups/members" class="table table-striped table-hover" data-nextstart="{group.membersNextStart}">
     <tbody>
+    <!-- IMPORT partials/groups/groupOnlineCount.tpl -->
     {{{each group.members}}}
     <tr data-uid="{group.members.uid}">
-        <!-- IMPORT partials/groups/groupOnlineCount.tpl -->
         <td>
             <a href="{config.relative_path}/user/{group.members.userslug}">{buildAvatar(group.members, "sm", true)}</a>
         </td>

--- a/themes/nodebb-theme-persona/templates/partials/groups/userOnlineCount.tpl
+++ b/themes/nodebb-theme-persona/templates/partials/groups/userOnlineCount.tpl
@@ -1,1 +1,1 @@
-<h6> ({groups.onlineUserCount}) </h6>
+<h7> ({groups.onlineUserCount}) </h7>


### PR DESCRIPTION
- Overview
  - Fixed parenthesis for online count being on next line for User page
  - Fixed duplicate display of online count for Group display
  - Separated the partials for Groups and Group display

- Changes made in following files:
  - themes/nodebb-theme-persona/templates/partials/users_list_menu.tpl (User page)
  - themes/nodebb-theme-persona/templates/partials/groups/userOnlineCount.tpl (Groups page)
  - themes/nodebb-theme-persona/templates/partials/groups/memberlist.tpl (Group page)
- Files added:
  - themes/nodebb-theme-persona/templates/partials/groups/groupsOnlineCount.tpl (Count for User page)