### PR TITLE
Fixed online user count not displaying

### DIFF
--- a/themes/nodebb-theme-persona/templates/partials/groups/userOnlineCount.tpl
+++ b/themes/nodebb-theme-persona/templates/partials/groups/userOnlineCount.tpl
@@ -1,1 +1,1 @@
-<h7> ({groups.onlineUserCount}) </h7>
+<h7> ({userCount}) </h7>


### PR DESCRIPTION
Fixed online count for User page not showing up

Changes made in following files:

- themes/nodebb-theme-persona/templates/partials/users_list_menu.tpl (User page)