### PR TITLE
Implement UI for ungrouped topics page

### DIFF
--- a/install/data/navigation.json
+++ b/install/data/navigation.json
@@ -42,6 +42,14 @@
 		"text": "[[global:header.popular]]"
 	},
 	{
+		"route": "/ungrouped",
+		"title": "Ungrouped",
+		"enabled": true,
+		"iconClass": "fa-unlink",
+		"textClass": "visible-xs-inline",
+		"text": "Ungrouped posts"
+	},
+	{
 		"route": "/users",
 		"title": "[[global:header.users]]",
 		"enabled": true,
@@ -75,7 +83,7 @@
 		"text": "Career"
 	},
 	{
-		"route": "/bugs",
+		"route": "/bug",
 		"title": "Bug",
 		"enabled": true,
 		"iconClass": "fa-bug",

--- a/install/data/navigation.json
+++ b/install/data/navigation.json
@@ -83,7 +83,7 @@
 		"text": "Career"
 	},
 	{
-		"route": "/bug",
+		"route": "/bugs",
 		"title": "Bug",
 		"enabled": true,
 		"iconClass": "fa-bug",

--- a/public/openapi/read.yaml
+++ b/public/openapi/read.yaml
@@ -332,5 +332,7 @@ paths:
     $ref: 'read/groups/slug.yaml'
   "/api/groups/{slug}/members":
     $ref: 'read/groups/slug/members.yaml'
+  /api/bugs:
+    $ref: 'read/bugs.yaml'
   /api/outgoing:
     $ref: 'read/outgoing.yaml'

--- a/public/openapi/read.yaml
+++ b/public/openapi/read.yaml
@@ -252,6 +252,8 @@ paths:
     $ref: 'read/tags/tag.yaml'
   /api/popular:
     $ref: 'read/popular.yaml'
+  /api/ungrouped:
+    $ref: 'read/ungrouped.yaml'
   /api/top:
     $ref: 'read/top.yaml'
   "/api/category/{category_id}/{slug}":
@@ -330,7 +332,5 @@ paths:
     $ref: 'read/groups/slug.yaml'
   "/api/groups/{slug}/members":
     $ref: 'read/groups/slug/members.yaml'
-  /api/bugs:
-    $ref: 'read/bugs.yaml'
   /api/outgoing:
     $ref: 'read/outgoing.yaml'

--- a/public/openapi/read/ungrouped.yaml
+++ b/public/openapi/read/ungrouped.yaml
@@ -1,0 +1,242 @@
+get:
+  tags:
+    - topics
+  summary: Get ungrouped topics
+  description: Returns a list of the current user's ungrouped topics.
+  responses:
+    "200":
+      description: An array of unread topic objects sorted by the last post's timestamp.
+      content:
+        application/json:
+          schema:
+            allOf:
+              - type: object
+                properties:
+                  showSelect:
+                    type: boolean
+                  showTopicTools:
+                    type: boolean
+                  nextStart:
+                    type: number
+                  topics:
+                    type: array
+                    items:
+                      allOf:
+                        - $ref: ../components/schemas/TopicObject.yaml#/TopicObjectSlim
+                        - type: object
+                          properties:
+                            title:
+                              type: string
+                            slug:
+                              type: string
+                            teaserPid:
+                              type: number
+                              nullable: true
+                            titleRaw:
+                              type: string
+                            category:
+                              type: object
+                              properties:
+                                cid:
+                                  type: number
+                                  description: A category identifier
+                                name:
+                                  type: string
+                                slug:
+                                  type: string
+                                icon:
+                                  type: string
+                                backgroundImage:
+                                  nullable: true
+                                imageClass:
+                                  nullable: true
+                                  type: string
+                                bgColor:
+                                  type: string
+                                color:
+                                  type: string
+                                disabled:
+                                  type: number
+                            user:
+                              type: object
+                              properties:
+                                uid:
+                                  type: number
+                                  description: A user identifier
+                                username:
+                                  type: string
+                                  description: A friendly name for a given user account
+                                displayname:
+                                  type: string
+                                  description: This is either username or fullname depending on forum and user settings
+                                fullname:
+                                  type: string
+                                userslug:
+                                  type: string
+                                  description: An URL-safe variant of the username (i.e. lower-cased, spaces
+                                    removed, etc.)
+                                reputation:
+                                  type: number
+                                postcount:
+                                  type: number
+                                picture:
+                                  nullable: true
+                                  type: string
+                                signature:
+                                  nullable: true
+                                  type: string
+                                banned:
+                                  type: number
+                                status:
+                                  type: string
+                                icon:text:
+                                  type: string
+                                  description: A single-letter representation of a username. This is used in the
+                                    auto-generated icon given to users without
+                                    an avatar
+                                icon:bgColor:
+                                  type: string
+                                  description: A six-character hexadecimal colour code assigned to the user. This
+                                    value is used in conjunction with
+                                    `icon:text` for the user's auto-generated
+                                    icon
+                                  example: "#f44336"
+                                banned_until_readable:
+                                  type: string
+                              required:
+                                - uid
+                                - username
+                                - userslug
+                                - reputation
+                                - postcount
+                                - picture
+                                - signature
+                                - banned
+                                - status
+                                - icon:text
+                                - icon:bgColor
+                                - banned_until_readable
+                            teaser:
+                              type: object
+                              nullable: true
+                              properties:
+                                pid:
+                                  type: number
+                                uid:
+                                  type: number
+                                  description: A user identifier
+                                timestamp:
+                                  type: number
+                                tid:
+                                  type: number
+                                  description: A topic identifier
+                                content:
+                                  type: string
+                                timestampISO:
+                                  type: string
+                                  description: An ISO 8601 formatted date string (complementing `timestamp`)
+                                user:
+                                  type: object
+                                  properties:
+                                    uid:
+                                      type: number
+                                      description: A user identifier
+                                    username:
+                                      type: string
+                                      description: A friendly name for a given user account
+                                    userslug:
+                                      type: string
+                                      description: An URL-safe variant of the username (i.e. lower-cased, spaces
+                                        removed, etc.)
+                                    picture:
+                                      nullable: true
+                                      type: string
+                                    icon:text:
+                                      type: string
+                                      description: A single-letter representation of a username. This is used in the
+                                        auto-generated icon given to users
+                                        without an avatar
+                                    icon:bgColor:
+                                      type: string
+                                      description: A six-character hexadecimal colour code assigned to the user. This
+                                        value is used in conjunction with
+                                        `icon:text` for the user's
+                                        auto-generated icon
+                                      example: "#f44336"
+                                index:
+                                  type: number
+                            tags:
+                              type: array
+                              items:
+                                $ref: ../components/schemas/TagObject.yaml#/TagObject
+                            isOwner:
+                              type: boolean
+                            ignored:
+                              type: boolean
+                            unread:
+                              type: boolean
+                            bookmark:
+                              nullable: true
+                            unreplied:
+                              type: boolean
+                            icons:
+                              type: array
+                              items:
+                                type: string
+                            index:
+                              type: number
+                  topicCount:
+                    type: number
+                  title:
+                    type: string
+                  pageCount:
+                    type: number
+                  allCategoriesUrl:
+                    type: string
+                  selectedCategory:
+                    type: object
+                    properties:
+                      icon:
+                        type: string
+                      name:
+                        type: string
+                      bgColor:
+                        type: string
+                    nullable: true
+                  selectCategoryLabel:
+                    type: string
+                  selectedCids:
+                    type: array
+                    items:
+                      type: number
+                  filters:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        name:
+                          type: string
+                        url:
+                          type: string
+                        selected:
+                          type: boolean
+                        filter:
+                          type: string
+                        icon:
+                          type: string
+                  selectedFilter:
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                      url:
+                        type: string
+                      selected:
+                        type: boolean
+                      filter:
+                        type: string
+                      icon:
+                        type: string
+              - $ref: ../components/schemas/Pagination.yaml#/Pagination
+              - $ref: ../components/schemas/Breadcrumbs.yaml#/Breadcrumbs
+              - $ref: ../components/schemas/CommonProps.yaml#/CommonProps

--- a/public/src/client/ungrouped.js
+++ b/public/src/client/ungrouped.js
@@ -1,0 +1,25 @@
+'use strict';
+
+define('forum/ungrouped', ['topicList', 'api', 'alerts'], function (topicList, api, alerts) {
+    const Ungrouped = {};
+
+    Ungrouped.init = function () {
+        app.enterRoom('ungrouped_topics');
+        handleGroupAssign();
+        topicList.init('ungroup');
+    };
+
+    function handleGroupAssign() {
+        $('[component="ungrouped/group"] [data-group]').off('click').on('click', function (e) {
+            const group = $(this).attr('data-group'); // Get group name
+            const tid = $(this).parent().parent().attr('data-tid'); // Get topic id
+
+            api.put(`/topics/${tid}/assign`, { groupName: group })
+                .then(() => alerts.success(`Topic assigned to ${group}`))
+                .catch(alerts.error);
+            e.preventDefault();
+        });
+    }
+
+    return Ungrouped;
+});

--- a/src/controllers/index.js
+++ b/src/controllers/index.js
@@ -21,6 +21,7 @@ Controllers.category = require('./category');
 Controllers.unread = require('./unread');
 Controllers.recent = require('./recent');
 Controllers.popular = require('./popular');
+Controllers.ungrouped = require('./ungrouped');
 Controllers.top = require('./top');
 Controllers.tags = require('./tags');
 Controllers.search = require('./search');

--- a/src/controllers/ungrouped.js
+++ b/src/controllers/ungrouped.js
@@ -1,0 +1,38 @@
+"use strict";
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.get = void 0;
+const helpers_1 = __importDefault(require("./helpers"));
+const topics_1 = __importDefault(require("../topics"));
+const user_1 = __importDefault(require("../user"));
+const groups_1 = __importDefault(require("../groups"));
+// eslint-disable-next-line import/prefer-default-export
+const get = function (req, res, next) {
+    return __awaiter(this, void 0, void 0, function* () {
+        const { uid } = req;
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+        const ungroupedTopicsData = yield topics_1.default.getUngroupedTopics(uid); // Ungrouped topics
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+        const userGroups = (yield groups_1.default.getUserGroups([uid]))[0];
+        if (!ungroupedTopicsData || !userGroups) {
+            return next();
+        }
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call
+        const [canPost] = yield user_1.default.exists([uid]);
+        const breadcrumbs = [{ text: 'Ungrouped' }];
+        const data = Object.assign(Object.assign({}, ungroupedTopicsData), { groups: userGroups, uid: uid, canPost, title: 'Ungrouped Topics', breadcrumbs: helpers_1.default.buildBreadcrumbs(breadcrumbs) });
+        res.render('ungrouped', data);
+    });
+};
+exports.get = get;

--- a/src/controllers/ungrouped.ts
+++ b/src/controllers/ungrouped.ts
@@ -1,0 +1,57 @@
+import { Request, Response, NextFunction } from 'express';
+
+import helpers from './helpers';
+import Topics from '../topics';
+import User from '../user';
+import Groups from '../groups';
+import { TopicObject } from '../types/topic';
+import { GroupFullObject } from '../types/group';
+import { Breadcrumb } from '../types';
+
+interface GetRequest extends Request {
+  uid: number;
+}
+
+interface UngroupedOutputData extends TopicData {
+  groups: GroupFullObject[];
+  uid: number;
+  title: string;
+  breadcrumbs: Breadcrumb
+}
+
+interface TopicData { // Consistent with inteface in src/topics/ungrouped.js
+  tids: string[];
+  nextStart: number;
+  topicsCount: number;
+  topics: TopicObject[];
+}
+
+// eslint-disable-next-line import/prefer-default-export
+export const get = async function (req: GetRequest, res: Response, next: NextFunction) {
+    const { uid } = req;
+
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+    const ungroupedTopicsData = await Topics.getUngroupedTopics(uid) as TopicData; // Ungrouped topics
+
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+    const userGroups = (await Groups.getUserGroups([uid]) as GroupFullObject[][])[0];
+
+    if (!ungroupedTopicsData || !userGroups) {
+        return next();
+    }
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call
+    const [canPost] = await User.exists([uid]) as boolean[];
+
+    const breadcrumbs = [{ text: 'Ungrouped' }];
+
+    const data = {
+        ...ungroupedTopicsData,
+        groups: userGroups,
+        uid: uid,
+        canPost,
+        title: 'Ungrouped Topics',
+        breadcrumbs: helpers.buildBreadcrumbs(breadcrumbs),
+    } as UngroupedOutputData;
+
+    res.render('ungrouped', data);
+};

--- a/src/install.js
+++ b/src/install.js
@@ -456,12 +456,12 @@ async function createCategories() {
 }
 
 async function createMenuItems() {
-    const db = require('./database');
+    // const db = require('./database');
 
-    const exists = await db.exists('navigation:enabled');
-    if (exists) {
-        return;
-    }
+    // const exists = await db.exists('navigation:enabled');
+    // if (exists) {
+    //     return;
+    // }
     const navigation = require('./navigation/admin');
     const data = require('../install/data/navigation.json');
     await navigation.save(data);

--- a/src/install.js
+++ b/src/install.js
@@ -456,12 +456,12 @@ async function createCategories() {
 }
 
 async function createMenuItems() {
-    // const db = require('./database');
+    const db = require('./database');
 
-    // const exists = await db.exists('navigation:enabled');
-    // if (exists) {
-    //     return;
-    // }
+    const exists = await db.exists('navigation:enabled');
+    if (exists) {
+        return;
+    }
     const navigation = require('./navigation/admin');
     const data = require('../install/data/navigation.json');
     await navigation.save(data);

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -79,6 +79,7 @@ _mounts.tags = (app, name, middleware, controllers) => {
 _mounts.category = (app, name, middleware, controllers) => {
     setupPageRoute(app, '/categories', [], controllers.categories.list);
     setupPageRoute(app, '/popular', [], controllers.popular.get);
+    setupPageRoute(app, '/ungrouped', [], controllers.ungrouped.get);
     setupPageRoute(app, '/recent', [], controllers.recent.get);
     setupPageRoute(app, '/top', [], controllers.top.get);
     setupPageRoute(app, '/unread', [middleware.ensureLoggedIn], controllers.unread.get);

--- a/src/topics/ungrouped.js
+++ b/src/topics/ungrouped.js
@@ -51,7 +51,6 @@ module.exports = function (Topics) {
      */
     Topics.assignTopicToGroup = function (tid, groupName) {
         return __awaiter(this, void 0, void 0, function* () {
-            console.log(groupName);
             yield Topics.setTopicFields(tid, {
                 group: groupName,
             });

--- a/src/topics/ungrouped.ts
+++ b/src/topics/ungrouped.ts
@@ -66,7 +66,6 @@ export = function (Topics: TopicsI) {
      * @param groupName name of group
      */
     Topics.assignTopicToGroup = async function (tid, groupName) {
-        console.log(groupName);
         await Topics.setTopicFields(tid, {
             group: groupName,
         });

--- a/test/controllers.js
+++ b/test/controllers.js
@@ -167,6 +167,45 @@ describe('Controllers', () => {
             });
         });
 
+        it('should load ungrouped', (done) => {
+            meta.configs.set('homePageRoute', 'ungrouped', (err) => {
+                assert.ifError(err);
+
+                request(nconf.get('url'), (err, res, body) => {
+                    assert.ifError(err);
+                    assert.equal(res.statusCode, 200);
+                    assert(body);
+                    done();
+                });
+            });
+        });
+
+        it('should load ungrouped with unassigned topics', (done) => {
+            request(`${nconf.get('url')}/api/ungrouped`, { json: true }, (err, res, body) => {
+                assert.ifError(err);
+                assert.equal(res.statusCode, 200);
+                assert(body);
+                const numTopics = body.topics.length; // Initial number of topics
+
+                topics.post({ // Post new topic
+                    uid: fooUid,
+                    title: 'topic title',
+                    content: 'test topic content',
+                    cid: cid,
+                }, (err) => {
+                    assert.ifError(err);
+                    request(`${nconf.get('url')}/api/ungrouped`, { json: true }, (err, res, body) => {
+                        assert.ifError(err);
+                        assert.equal(res.statusCode, 200);
+                        assert(body);
+                        // Ensure there is another topics
+                        assert.equal(body.topics.length, numTopics + 1);
+                        done();
+                    });
+                });
+            });
+        });
+
         it('should load category', (done) => {
             meta.configs.set('homePageRoute', 'category/1/test-category', (err) => {
                 assert.ifError(err);

--- a/themes/nodebb-theme-persona/templates/partials/ungrouped_topics_list.tpl
+++ b/themes/nodebb-theme-persona/templates/partials/ungrouped_topics_list.tpl
@@ -1,0 +1,115 @@
+<ul component="category" class="topic-list" itemscope itemtype="http://www.schema.org/ItemList" data-nextstart="{nextStart}" data-set="{set}">
+    {{{each topics}}}
+    <li component="category/topic" class="row clearfix category-item {function.generateTopicClass}" <!-- IMPORT partials/data/category.tpl -->>
+        <link itemprop="url" content="{config.relative_path}/topic/{../slug}" />
+        <meta itemprop="name" content="{function.stripTags, ../title}" />
+        <meta itemprop="itemListOrder" content="descending" />
+        <meta itemprop="position" content="{../index}" />
+        <a id="{../index}" data-index="{../index}" component="topic/anchor"></a>
+
+        <div class="col-md-6 col-sm-9 col-xs-10 content">
+            <div class="avatar pull-left">
+                <!-- IF showSelect -->
+                <div class="select" component="topic/select">
+                    {{{ if ./thumbs.length }}}
+                    <img src="{./thumbs.0.url}" class="user-img not-responsive" />
+                    {{{ else }}}
+                    {buildAvatar(../user, "46", true, "not-responsive")}
+                    {{{ end }}}
+                    <i class="fa fa-check"></i>
+                </div>
+                <!-- ENDIF showSelect -->
+
+                <!-- IF !showSelect -->
+                <a href="<!-- IF topics.user.userslug -->{config.relative_path}/user/{topics.user.userslug}<!-- ELSE -->#<!-- ENDIF topics.user.userslug -->" class="pull-left">
+                    {{{ if ./thumbs.length }}}
+                    <img src="{./thumbs.0.url}" class="user-img not-responsive" />
+                    {{{ else }}}
+                    {buildAvatar(../user, "46", true, "not-responsive")}
+                    {{{ end }}}
+                </a>
+                <!-- ENDIF !showSelect -->
+            </div>
+
+            <h2 component="topic/header" class="title">
+                <i component="topic/scheduled" class="fa fa-clock-o <!-- IF !topics.scheduled -->hide<!-- ENDIF !topics.scheduled -->" title="[[topic:scheduled]]"></i>
+                <i component="topic/pinned" class="fa fa-thumb-tack <!-- IF (topics.scheduled || !topics.pinned) -->hide<!-- ENDIF (topics.scheduled || !topics.pinned) -->" title="{{{ if !../pinExpiry }}}[[topic:pinned]]{{{ else }}}[[topic:pinned-with-expiry, {../pinExpiryISO}]]{{{ end }}}"></i>
+                <i component="topic/locked" class="fa fa-lock <!-- IF !topics.locked -->hide<!-- ENDIF !topics.locked -->" title="[[topic:locked]]"></i>
+                <i component="topic/moved" class="fa fa-arrow-circle-right <!-- IF !topics.oldCid -->hide<!-- ENDIF !topics.oldCid -->" title="[[topic:moved]]"></i>
+                {{{each topics.icons}}}{@value}{{{end}}}
+
+
+                <!-- IF !topics.noAnchor -->
+                <a href="{config.relative_path}/topic/{topics.slug}<!-- IF topics.bookmark -->/{topics.bookmark}<!-- ENDIF topics.bookmark -->">{topics.title}</a><br />
+                <!-- ELSE -->
+                <span>{topics.title}</span><br />
+                <!-- ENDIF !topics.noAnchor -->
+
+                <!-- IF !template.category -->
+                <small>
+                    <a href="{config.relative_path}/category/{topics.category.slug}"><span class="fa-stack fa-lg" style="{function.generateCategoryBackground, topics.category}"><i style="color:{topics.category.color};" class="fa {topics.category.icon} fa-stack-1x"></i></span> {topics.category.name}</a> &bull;
+                </small>
+                <!-- ENDIF !template.category -->
+
+                {{{ if topics.tags.length }}}
+                <span class="tag-list hidden-xs">
+                    {{{each topics.tags}}}
+                    <a href="{config.relative_path}/tags/{topics.tags.valueEncoded}"><span class="tag tag-item tag-class-{topics.tags.class}">{topics.tags.valueEscaped}</span></a>
+                    {{{end}}}
+                    <small>&bull;</small>
+                </span>
+                {{{ end }}}
+
+                <small class="hidden-xs"><span class="timeago" title="{topics.timestampISO}"></span> &bull; <a href="<!-- IF topics.user.userslug -->{config.relative_path}/user/{topics.user.userslug}<!-- ELSE -->#<!-- ENDIF topics.user.userslug -->">{topics.user.displayname}</a></small>
+                <small class="visible-xs-inline">
+                    <!-- IF topics.teaser.timestamp -->
+                    <span class="timeago" title="{topics.teaser.timestampISO}"></span>
+                    <!-- ELSE -->
+                    <span class="timeago" title="{topics.timestampISO}"></span>
+                    <!-- ENDIF topics.teaser.timestamp -->
+                </small>
+            </h2>
+        </div>
+
+        <div class="mobile-stat col-xs-2 visible-xs text-right">
+            <span class="human-readable-number">{topics.postcount}</span> <a href="{config.relative_path}/topic/{topics.slug}/{topics.teaser.index}"><i class="fa fa-arrow-circle-right"></i></a>
+        </div>
+
+        <div class="col-md-1 hidden-sm hidden-xs stats stats-votes">
+            <!-- IF !reputation:disabled -->
+            <span class="human-readable-number" title="{topics.votes}">{topics.votes}</span><br />
+            <small>[[global:votes]]</small>
+            <!-- END -->
+        </div>
+
+        <div class="col-md-1 hidden-sm hidden-xs stats stats-postcount">
+            <span class="human-readable-number" title="{topics.postcount}">{topics.postcount}</span><br />
+            <small>[[global:posts]]</small>
+        </div>
+
+        <div class="col-md-1 hidden-sm hidden-xs stats stats-viewcount">
+            <span class="human-readable-number" title="{topics.viewcount}">{topics.viewcount}</span><br />
+            <small>[[global:views]]</small>
+        </div>
+
+        <div class="col-md-3 col-sm-3 teaser hidden-xs" component="topic/teaser">
+            {{{ if topics.isOwner }}}
+            <div class="btn-group">
+                <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown">
+                    <span class="visible-sm-inline visible-md-inline visible-lg-inline">Assign to group</span><span class="visible-xs-inline"><i class="fa fa-fw {selectedFilter.icon}"></i></span> <span class="caret"></span>
+                </button>
+                <ul id="group-select-list" component="ungrouped/group" class="dropdown-menu" aria-labelledby="group_dropdown" data-tid={topics.tid}>
+                    {{{each groups }}}
+                    <li>
+                        <a href="#" class="user-status" data-group="{groups.displayName}" >
+                            <span>{groups.displayName}</span>
+                        </a>
+                    </li>
+                    {{{ end }}}                    
+                </ul>
+            </div>
+            {{{ end }}}
+        </div>
+    </li>
+    {{{end}}}
+</ul>

--- a/themes/nodebb-theme-persona/templates/ungrouped.tpl
+++ b/themes/nodebb-theme-persona/templates/ungrouped.tpl
@@ -1,0 +1,28 @@
+<!-- IMPORT partials/breadcrumbs.tpl -->
+<div data-widget-area="header">
+    {{{each widgets.header}}}
+    {{widgets.header.html}}
+    {{{end}}}
+</div>
+<div class="ungrouped">
+    <div class="topic-list-header btn-toolbar">
+        <div class="pull-left">
+            <!-- IF canPost -->
+            <!-- IMPORT partials/buttons/newTopic.tpl -->
+            <!-- ELSE -->
+            <a component="category/post/guest" href="{config.relative_path}/login" class="btn btn-primary">[[category:guest-login-post]]</a>
+            <!-- ENDIF canPost -->
+        </div>
+    </div>
+    <div class="category">
+        <!-- IF !topics.length -->
+        <div class="alert alert-warning" id="category-no-topics">There are no ungrouped topics</div>
+        <!-- ENDIF !topics.length -->
+
+        <!-- IMPORT partials/ungrouped_topics_list.tpl -->
+
+        <!-- IF config.usePagination -->
+            <!-- IMPORT partials/paginator.tpl -->
+        <!-- ENDIF config.usePagination -->
+    </div>
+</div>


### PR DESCRIPTION
#### Implements a UI to allow users to assign topics to a group they are a part of.

Resolves #22

This new feature provides a new page that can be accessed in the navigation panel at the top of NodeBB. This page consists of a list of topics (similar to 'popular' page) that displays all unassigned/ ungrouped topics.

A dropdown will appear next to all topics that the user owns, where they can select which group to assign the topic to.
Once selected, the topic can be found on the details page of the selected group. (Note newly assigned topics will disappear once the page is refreshed).

#### View of 'ungrouped' page as a guest (not logged in)
![Screen Shot 2023-10-10 at 11 14 23 PM](https://github.com/CMU-313/fall23-nodebb-formula1/assets/74222402/92bbe2ff-efea-4890-996d-c675ce8f8988)


#### View of 'ungrouped' page as a user logged in
![Screen Shot 2023-10-10 at 11 16 58 PM](https://github.com/CMU-313/fall23-nodebb-formula1/assets/74222402/101749b4-97a8-4279-a84f-0d44e77bfda7)

#### Assign an owned topic to a group ('nodebb updates')
![Screen Shot 2023-10-10 at 11 19 09 PM](https://github.com/CMU-313/fall23-nodebb-formula1/assets/74222402/9c060dc6-8075-41c3-b083-f301c53941c5)

#### View the topic in group details page
![Screen Shot 2023-10-10 at 11 19 29 PM](https://github.com/CMU-313/fall23-nodebb-formula1/assets/74222402/dd8f026d-7da7-442a-bd44-48fcdbe1d664)

